### PR TITLE
Add south_migrations to package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
         'database_files.management',
         'database_files.management.commands',
         'database_files.migrations',
+        'database_files.south_migrations',
     ],
     #https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
As @rhunwicks pointed out in https://github.com/chrisspen/django-database-files-3000/commit/4fdbcb4e85705e8ca7b623b69f1e76ea944a2a98, I had forgotten to add the `south_migrations` directory to the packages list in `setup.py`. I tested this by running `python setup.py sdist` and making sure that the `south_migrations` folder is present in the tarball it creates.