### PR TITLE
trusty does not have 3.5 distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 -   sudo add-apt-repository -y ppa:fkrull/deadsnakes
 -   sudo apt-get -yq update
 -   sudo apt-get -yq install python3.6 python3.6-dev
--   pip install tox pylint
+-   pip install tox "pylint<2.0"
 script:
 -   ./pep8.sh
 -   tox

--- a/database_files/storage.py
+++ b/database_files/storage.py
@@ -53,7 +53,7 @@ class DatabaseStorage(FileSystemStorage):
                 size = fh.size
             else:
                 # Otherwise we don't know where the file is.
-                return
+                return None
         # Normalize the content to a new file object.
         #fh = StringIO(content)
         fh = six.BytesIO(content)

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,13 @@
 #https://pypi.python.org/pypi/Django/1.10
 # Note, several versions support Python 3.2, but Pip has dropped support, so we can't test them.
 # See https://github.com/travis-ci/travis-ci/issues/5485
-envlist = py{27,34}-django{17,18},py{27,34,35}-django{19},py{27,34,35}-django{110},py{27,34,35,36}-django{111}
+envlist = py{27}-django{17,18},py{27,35}-django{19},py{27,35}-django{110},py{27,35,36}-django{111}
 recreate = True
 
 [testenv]
 basepython =
     py27: python2.7
     py32: python3.2
-    py34: python3.4
     py35: python3.5
     py36: python3.6
 deps =


### PR DESCRIPTION
Switching to xenial as recommended here: https://travis-ci.community/t/unable-to-download-python-3-7-archive-on-travis-ci/639