### PR TITLE
Django requirement

### DIFF
--- a/database_files/models.py
+++ b/database_files/models.py
@@ -68,7 +68,11 @@ class File(models.Model):
     
     @content.setter
     def content(self, v):
-        self._content = base64.b64encode(v)
+        c = base64.b64encode(v)
+        if not isinstance(c, six.string_types):
+            c = c.decode('utf-8')
+        self._content = c
+
         
     @property
     def content_hash(self):

--- a/pip-requirements-min-django.txt
+++ b/pip-requirements-min-django.txt
@@ -1,2 +1,2 @@
-Django>=1.7
-Django<2
+Django>=1.11
+Django<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -5,21 +5,19 @@
 #https://pypi.python.org/pypi/Django/1.10
 # Note, several versions support Python 3.2, but Pip has dropped support, so we can't test them.
 # See https://github.com/travis-ci/travis-ci/issues/5485
-envlist = py{27}-django{17,18},py{27,35}-django{19},py{27,35}-django{110},py{27,35,36}-django{111}
+envlist = py{27,35,36}-django{111},py{35,36}-django{20,21,22}
 recreate = True
 
 [testenv]
 basepython =
     py27: python2.7
-    py32: python3.2
     py35: python3.5
     py36: python3.6
 deps =
     -r{toxinidir}/pip-requirements.txt
     -r{toxinidir}/pip-requirements-test.txt
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
+    django20: Django>=2.0<2.1
+    django21: Django>=2.1<2.2
+    django22: Django>=2.2<2.3
 commands = django-admin.py test --traceback --pythonpath=. --settings=database_files.tests.settings database_files.tests.tests.DatabaseFilesTestCase{env:TESTNAME:}


### PR DESCRIPTION
The old requirements file restricts to <2; this version allows Django 1.11 through 2.2.